### PR TITLE
Remove `playtime` save value

### DIFF
--- a/game/config.rpy
+++ b/game/config.rpy
@@ -17,7 +17,7 @@ init -1 python hide:
     # Basic settings.
     config.name = "First Snow"
     config.version = "1.5.3"
-    config.patch_version = 5
+    config.patch_version = 6
     config.developer = "auto"
 
     # Window.

--- a/game/lib/context_manager_ren.py
+++ b/game/lib/context_manager_ren.py
@@ -126,12 +126,10 @@ class GameContext(NoRollback):
     @staticmethod
     def store_scene(info: SaveFileInfo) -> None:
         """
-        Adds the current scene and total game runtime to the save file.
+        Adds the current scene to the save file.
         """
         
         info['scene'] = store.current_scene
-        # TODO Do we even need this? This is already stored in "_game_runtime".
-        info['playtime'] = get_game_runtime()
     
     @staticmethod
     def store_patch_version(info: SaveFileInfo) -> None:

--- a/game/ui.rpy
+++ b/game/ui.rpy
@@ -2120,7 +2120,7 @@ screen saveload(save):
                     $ extra = renpy.slot_json(name)
                     $ outdated = extra.get('patch_version', 1) < config.patch_version
                     $ ttitle = GameContext.get_scene_title(extra['scene'])
-                    $ ttime = int(extra['_game_runtime']) // 60
+                    $ ttime = int(extra['_game_runtime'] if not outdated else extra['playtime']) // 60
                     frame:
                         background "ui/saveload/slot.webp"
                         xysize (654, 125)

--- a/game/ui.rpy
+++ b/game/ui.rpy
@@ -2120,7 +2120,7 @@ screen saveload(save):
                     $ extra = renpy.slot_json(name)
                     $ outdated = extra.get('patch_version', 1) < config.patch_version
                     $ ttitle = GameContext.get_scene_title(extra['scene'])
-                    $ ttime = int(extra['playtime']) // 60
+                    $ ttime = int(extra['_game_runtime']) // 60
                     frame:
                         background "ui/saveload/slot.webp"
                         xysize (654, 125)

--- a/game/ui.rpy
+++ b/game/ui.rpy
@@ -2120,7 +2120,7 @@ screen saveload(save):
                     $ extra = renpy.slot_json(name)
                     $ outdated = extra.get('patch_version', 1) < config.patch_version
                     $ ttitle = GameContext.get_scene_title(extra['scene'])
-                    $ ttime = int(extra['_game_runtime'] if not outdated else extra['playtime']) // 60
+                    $ ttime = int(extra.get('_game_runtime', extra.get('playtime', 0)) ) // 60
                     frame:
                         background "ui/saveload/slot.webp"
                         xysize (654, 125)


### PR DESCRIPTION
This PR removes a reduntant value in the save files that was keeping the time spent on a given playthrough. This value is nowadays already added to save files automatically by Ren'Py, so we don't need a custom variable for this anymore.